### PR TITLE
ci: switch macOS Intel builds to Rosetta 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
             [
               "Lnx x64/ubuntu-latest",
               "Lnx A64/ubuntu-24.04-arm",
-              "Mac x64/macos-15-intel",
+              "Mac x64/macos-latest+rosetta2",
               "Mac A64/macos-latest",
             empty] as $runners |
             
@@ -76,6 +76,8 @@ jobs:
               (if $qemuSystem then {
                 "aarch64-linux": "arm64",
               }[$qemuSystem] else null end) as $qemuSystemForAction |
+              ($runner | split("+rosetta2")) as [$runner, $rosetta2] |
+              ($rosetta2 != null) as $rosetta2 |
               # (if $qemuSystem then $subsets[] else "all" end) as $subset |
               $subsets[] as $subset |
               select(($runner | startswith("macos")) or ($subset != "mame")) |
@@ -89,7 +91,7 @@ jobs:
               .) as $displayNixpkgs |
               ("\($displayRunner)-\($displayNixpkgs)-\($subset)" | gsub(" "; "-")) as $cacheName |
               (if $qemuSystem then "TODO make qemu builds work again" | error else . end) |
-              {$displayRunner, $runner, $qemuSystem, $qemuSystemForAction, $displayNixpkgs, $nixpkgs, $nixpkgsPath, $subset, $nurRepo, $cachixName, $cacheName}
+              {$displayRunner, $runner, $qemuSystem, $qemuSystemForAction, $rosetta2, $displayNixpkgs, $nixpkgs, $nixpkgsPath, $subset, $nurRepo, $cachixName, $cacheName}
             ]}
             
           EOF
@@ -177,6 +179,10 @@ jobs:
       uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
       with:
         platforms: ${{ matrix.qemuSystemForAction }}
+    - name: Install Rosetta 2
+      if: ${{ matrix.rosetta2 }}
+      run: |
+        softwareupdate --install-rosetta --agree-to-license
     - name: Install nix
       uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
       with:
@@ -249,7 +255,7 @@ jobs:
           outputs = {self, Rhys-T, nixpkgs}: let inherit (nixpkgs) lib; in {
             cacheOutputs = lib.pipe Rhys-T.legacyPackages [
               (builtins.mapAttrs (system: ps: ps.ci.cacheOutputsAsAttrs or null))
-              (lib.filterAttrs (system: co: system == $(nix-instantiate --eval '<nixpkgs>' -A system) && co != null))
+              (lib.filterAttrs (system: co: system == ${{ matrix.rosetta2 && '"x86_64-darwin"' || '$(nix-instantiate --eval ''<nixpkgs>'' -A system)' }} && co != null))
             ];
           };
         }
@@ -258,14 +264,14 @@ jobs:
         nix flake lock "$tempFlake"
         nix shell github:Mic92/nix-fast-build 'nixpkgs#ansifilter' -c bash -c '
           set -o pipefail
-          nix-fast-build -f "$tempFlake#cacheOutputs" --skip-cached --no-nom --result-file /tmp/build-status.json 2>&1 | \
+          nix-fast-build -f "$tempFlake#cacheOutputs" --skip-cached --no-nom ${{ matrix.rosetta2 && '--systems x86_64-darwin' || '' }} --result-file /tmp/build-status.json 2>&1 | \
             tee >(ansifilter > /tmp/build-uncached.log)
         '
     - name: Upload build logs
       if: '!cancelled()'
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
       with:
-        name: Rhys-T-nur-packages-build-logs-${{ matrix.runner }}${{ matrix.qemuSystem && format('+qemu-{0}', matrix.qemuSystem) || '' }}-${{ matrix.nixpkgs }}-${{ matrix.subset }}
+        name: Rhys-T-nur-packages-build-logs-${{ matrix.runner }}${{ matrix.qemuSystem && format('+qemu-{0}', matrix.qemuSystem) || '' }}${{ matrix.rosetta2 && '+rosetta2' || '' }}-${{ matrix.nixpkgs }}-${{ matrix.subset }}
         path: |
           /tmp/tempFlake
           /tmp/build-status.json


### PR DESCRIPTION
The `macos-13` runner is [going away][] in November, and the newer Intel macOS runners are all paid 'larger' runners.

[going away]: https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down